### PR TITLE
Add HEADER to CSV copy statement

### DIFF
--- a/scripts/PSRA_copyTables.py
+++ b/scripts/PSRA_copyTables.py
@@ -408,7 +408,7 @@ def main ():
                                                                     structural_complete)
                         FROM /usr/src/app/cDamage/{prov}/cD_{prov}_dmg-mean_b0.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
 
@@ -450,7 +450,7 @@ def main ():
                                                                     structural_complete)
                         FROM /usr/src/app/cDamage/{prov}/cD_{prov}_dmg-mean_r2.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
 
@@ -492,7 +492,7 @@ def main ():
                                                                     structural_complete)
                         FROM /usr/src/app/eDamage/{prov}/eD_{prov}_damages-mean_b0.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
 
@@ -534,7 +534,7 @@ def main ():
                                                                     structural_complete)
                         FROM /usr/src/app/eDamage/{prov}/eD_{prov}_damages-mean_r2.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
 
@@ -554,7 +554,7 @@ def main ():
                                                                         annual_frequency_of_exceedence)
                         FROM /usr/src/app/ebRisk/{prov}/ebR_{prov}_agg_curves-stats_b0.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
     
@@ -574,7 +574,7 @@ def main ():
                                                                         annual_frequency_of_exceedence)
                         FROM /usr/src/app/ebRisk/{prov}/ebR_{prov}_agg_curves-stats_r2.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
     
@@ -614,7 +614,7 @@ def main ():
                                                                         structural)
                         FROM /usr/src/app/ebRisk/{prov}/ebR_{prov}_avg_losses-stats_b0.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
     
@@ -654,7 +654,7 @@ def main ():
                                                                         structural)
                         FROM /usr/src/app/ebRisk/{prov}/ebR_{prov}_avg_losses-stats_r2.csv
                             WITH 
-                            CSV ;'""".format(**{'prov':args.province})
+                            CSV HEADER ;'""".format(**{'prov':args.province})
     systemCall = ' '.join(systemCall.split())
     os.system(systemCall)
     


### PR DESCRIPTION
Special thanks to @drotheram for debugging OpenDRR/opendrr-api#105 and for authoring the commit in this pull request.

merge_csv() in OpenDRR/opendrr-api#105 has a small change in behaviour compared with the previous CSV merging code in add_data.sh as to whether the resulting CSV file contains HEADER or not on the first line.  So, the following new errors appeared with OpenDRR/opendrr-api#105:

```
copy psra_BC.psra_BC_cd_dmg_mean_b0(asset_id, "BldEpoch", "BldgType", "EqDesLev", "GenOcc", "GenType", "LandUse", "OccClass", "SAC", "SSC_Zone", "SauidID", adauid, cdname, cduid, csdname, csduid, dauid, ername, eruid, fsauid, prname, pruid, sauid, taxonomy, lon, lat, structural_no_damage, structural_slight, structural_moderate, structural_extensive, structural_complete) FROM /usr/src/app/cDamage/BC/cD_BC_dmg-mean_b0.csv WITH CSV ;
ERROR:  invalid input syntax for type double precision: "lon"
CONTEXT:  COPY psra_bc_cd_dmg_mean_b0, line 1, column lon: "lon"
copy psra_BC.psra_BC_cd_dmg_mean_r2(asset_id, "BldEpoch", "BldgType", "EqDesLev", "GenOcc", "GenType", "LandUse", "OccClass", "SAC", "SSC_Zone", "SauidID", adauid, cdname, cduid, csdname, csduid, dauid, ername, eruid, fsauid, prname, pruid, sauid, taxonomy, lon, lat, structural_no_damage, structural_slight, structural_moderate, structural_extensive, structural_complete) FROM /usr/src/app/cDamage/BC/cD_BC_dmg-mean_r2.csv WITH CSV ;
ERROR:  invalid input syntax for type double precision: "lon"
CONTEXT:  COPY psra_bc_cd_dmg_mean_r2, line 1, column lon: "lon"
copy psra_BC.psra_BC_ed_dmg_mean_b0(asset_id, "BldEpoch", "BldgType", "EqDesLev", "GenOcc", "GenType", "LandUse", "OccClass", "SAC", "SSC_Zone", "SauidID", adauid, cdname, cduid, csdname, csduid, dauid, ername, eruid, fsauid, prname, pruid, sauid, taxonomy, lon, lat, structural_no_damage, structural_slight, structural_moderate, structural_extensive, structural_complete) FROM /usr/src/app/eDamage/BC/eD_BC_damages-mean_b0.csv WITH CSV ;
ERROR:  invalid input syntax for type double precision: "lon"
CONTEXT:  COPY psra_bc_ed_dmg_mean_b0, line 1, column lon: "lon"
copy psra_BC.psra_BC_ed_dmg_mean_r2(asset_id, "BldEpoch", "BldgType", "EqDesLev", "GenOcc", "GenType", "LandUse", "OccClass", "SAC", "SSC_Zone", "SauidID", adauid, cdname, cduid, csdname, csduid, dauid, ername, eruid, fsauid, prname, pruid, sauid, taxonomy, lon, lat, structural_no_damage, structural_slight, structural_moderate, structural_extensive, structural_complete) FROM /usr/src/app/eDamage/BC/eD_BC_damages-mean_r2.csv WITH CSV ;
```

So, Drew came up with the elegant solution to change occurrences of `WITH CSV` to `WITH CSV HEADER` in scripts/PSRA_copyTables.py for consistency.
Drew checked the stack this morning and it appears like everything build properly.

To be merged in synchronous with OpenDRR/opendrr-api#105